### PR TITLE
Enable cross compilation (Docker) to aarch64-unknown-linux-musl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2623,6 +2623,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.21.0+1.1.1p"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0a8313729211913936f1b95ca47a5fc7f2e04cd658c115388287f8a8361008"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2631,6 +2640,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -4245,6 +4255,7 @@ dependencies = [
  "include_dir",
  "infer",
  "log",
+ "openssl",
  "prisma-client-rust",
  "ring",
  "rocket",

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 # ------------------------------------------------------------------------------
 
 FROM node:16-alpine3.14 as frontend
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -15,22 +16,39 @@ RUN npm run build
 # Cargo Build Stage
 # ------------------------------------------------------------------------------
 
-FROM rust:1-alpine3.15 as builder
-
-ENV RUSTFLAGS="-C target-feature=-crt-static"
-
-RUN apk add --no-cache --verbose musl-dev build-base sqlite openssl-dev
+# This stage is used for arm64, skipped otherwise by buildx
+FROM messense/rust-musl-cross:aarch64-musl AS arm64-backend
 
 WORKDIR /app
 
+COPY .cargo .cargo
 COPY core/ .
 
-RUN cargo build --release --target=x86_64-unknown-linux-musl
+# Workaround as otherwise container would err during crates.io index updating
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+
+RUN rustup target add aarch64-unknown-linux-musl && \
+    cargo build --release --target aarch64-unknown-linux-musl && \
+    cp target/aarch64-unknown-linux-musl/release/stump .
+
+# This stage is used for amd64, skipped otherwise by buildx
+FROM messense/rust-musl-cross:x86_64-musl AS amd64-backend
+
+WORKDIR /app
+
+COPY .cargo .cargo
+COPY core/ .
+
+RUN rustup target add x86_64-unknown-linux-musl && \
+    cargo build --release --target x86_64-unknown-linux-musl && \
+    cp target/x86_64-unknown-linux-musl/release/stump .
+
+# Conditional to skip non-targetarch build stages
+FROM ${TARGETARCH}-backend AS backend-build
 
 # ------------------------------------------------------------------------------
 # Final Stage
 # ------------------------------------------------------------------------------
-
 FROM alpine:latest
 
 RUN apk add --no-cache libstdc++
@@ -41,21 +59,21 @@ RUN adduser -D -s /bin/sh -u 1000 -G stump stump
 
 WORKDIR /
 
-# create the config and data directories
-RUN mkdir -p app
+# create the config, data and app directories
 RUN mkdir -p config
 RUN mkdir -p data
+RUN mkdir -p app
 
 # copy the binary
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/stump /app/stump
+COPY --from=backend-build /app/stump ./app/stump
 
 # copy the react build
-COPY --from=frontend /app/build /app/client
+COPY --from=frontend /app/build ./app/client
 
 # *sigh* Rocket requires the toml file at runtime
-COPY core/Rocket.toml /app/Rocket.toml
+COPY core/Rocket.toml ./app/Rocket.toml
 
-RUN chown stump:stump stump
+RUN chown stump:stump ./app/stump
 
 USER stump
 
@@ -68,4 +86,4 @@ ENV ROCKET_PROFILE=release
 ENV ROCKET_LOG_LEVEL=normal
 ENV ROCKET_PORT=10801
 
-CMD ["./stump"]
+CMD ["./app/stump"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 # ------------------------------------------------------------------------------
 
 FROM node:16-alpine3.14 as frontend
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -64,15 +65,15 @@ RUN mkdir -p data
 RUN mkdir -p app
 
 # copy the binary
-COPY --from=backend-build /app/stump /app/stump
+COPY --from=backend-build /app/stump ./app/stump
 
 # copy the react build
-COPY --from=frontend /app/build /app/client
+COPY --from=frontend /app/build ./app/client
 
 # *sigh* Rocket requires the toml file at runtime
-COPY core/Rocket.toml /app/Rocket.toml
+COPY core/Rocket.toml ./app/Rocket.toml
 
-RUN chown stump:stump stump
+RUN chown stump:stump ./app/stump
 
 USER stump
 
@@ -85,4 +86,4 @@ ENV ROCKET_PROFILE=release
 ENV ROCKET_LOG_LEVEL=normal
 ENV ROCKET_PORT=10801
 
-CMD ["./stump"]
+CMD ["./app/stump"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@
 # ------------------------------------------------------------------------------
 
 FROM node:16-alpine3.14 as frontend
-ARG TARGETARCH
 
 WORKDIR /app
 
@@ -65,15 +64,15 @@ RUN mkdir -p data
 RUN mkdir -p app
 
 # copy the binary
-COPY --from=backend-build /app/stump ./app/stump
+COPY --from=backend-build /app/stump /app/stump
 
 # copy the react build
-COPY --from=frontend /app/build ./app/client
+COPY --from=frontend /app/build /app/client
 
 # *sigh* Rocket requires the toml file at runtime
-COPY core/Rocket.toml ./app/Rocket.toml
+COPY core/Rocket.toml /app/Rocket.toml
 
-RUN chown stump:stump ./app/stump
+RUN chown stump:stump stump
 
 USER stump
 
@@ -86,4 +85,4 @@ ENV ROCKET_PROFILE=release
 ENV ROCKET_LOG_LEVEL=normal
 ENV ROCKET_PORT=10801
 
-CMD ["./app/stump"]
+CMD ["./stump"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,10 +8,12 @@ default-run = "stump"
 # TODO organize these
 prisma-client-rust = { git = "https://github.com/Brendonovich/prisma-client-rust", tag = "0.5.2" }
 serde = { version = "1.0", features = ["derive"] }
-rocket =  { version = "0.5.0-rc.2", features =  ["json" ] }
+rocket = { version = "0.5.0-rc.2", features = ["json"] }
 # rocket-session-store = "0.2.0"
 # rocket-session-store = { path = "../../../../../Documents/sandbox/clones/rocket-session-store", features = ["okapi"] }
-rocket-session-store = { git = "https://github.com/aaronleopold/rocket-session-store", branch = "develop", features = ["okapi"] }
+rocket-session-store = { git = "https://github.com/aaronleopold/rocket-session-store", branch = "develop", features = [
+  "okapi"
+] }
 # rocket_cors = "0.6.0-alpha1"
 # Note: not pointing to master caused some compilation issues. It's in alpha, so :)
 # See https://github.com/lawliet89/rocket_cors/pull/108
@@ -42,3 +44,9 @@ rocket_okapi = { version = "0.8.0-rc.2", features = ["rapidoc", "swagger"] }
 schemars = "0.8.10"
 fern = "0.6.1"
 toml = "0.5.9"
+
+[target.aarch64-unknown-linux-musl.dependencies]
+openssl = { version = "0.10.40", features = ["vendored"] }
+
+[target.x86_64-unknown-linux-musl.dependencies]
+openssl = { version = "0.10.40", features = ["vendored"] }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"website": "pnpm --filter @stump/website --",
 		"prepare": "husky install",
 		"build": "pnpm client build && pnpm core build",
-		"build:docker": "docker build -t stump ."
+		"build:docker": "docker buildx build --platform=linux/arm64,linux/amd64 -t stump ."
 	},
 	"devDependencies": {
 		"husky": "^7.0.2",


### PR DESCRIPTION
Resolves #21 

Naive and unoptimized approach for cross compilation during Docker build. Result is a multi-arch Docker image.

Cross compilation to aarch64 takes a while on my machine (~ 2hrs), but it works. amd64 version builds significantly faster (< 30mins).

Please be aware that you'll need to have buildx set up as described in [the Docker blog post for it](https://www.docker.com/blog/how-to-rapidly-build-multi-architecture-images-with-buildx/ ).

The conditional to skip non-targetarch build stages is described in [this blog post by Docker](https://www.docker.com/blog/advanced-dockerfiles-faster-builds-and-smaller-images-using-buildkit-and-multistage-builds/).

