### PR TITLE
Add GitHub Actions CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
       with:
         path: target
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install clippy
-      run: rustup component add clippy
     # run checks
+    - name: Run cargo check
+      run: cargo check
     - name: Run clippy
       run: cargo clippy
     - name: Run formatter
@@ -63,5 +63,9 @@ jobs:
     - name: Install dependencies
       run: pnpm install
     # run checks
-    - name: TypeScript checks
-      run: pnpm run checks
+    - name: TypeScript check for apps/client
+      run: pnpm tsc --noEmit
+      working-directory: apps/client
+    - name: TypeScript check for apps/website
+      run: pnpm tsc --noEmit
+      working-directory: apps/website

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+    # setup
+    - uses: actions/checkout@v3
+    - name: Cache cargo registry
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/registry
+        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+    - name: Cache cargo index
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/git
+        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+    - name: Cache cargo build
+      uses: actions/cache@v1
+      with:
+        path: target
+        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install clippy
+      run: rustup component add clippy
+    # run checks
+    - name: Run clippy
+      run: cargo clippy
+    - name: Run formatter
+      run: cargo fmt --check
+
+  typescript:
+    runs-on: ubuntu-latest
+    steps:
+    # setup
+    - uses: actions/checkout@v3
+    - name: Install Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 14
+    - uses: pnpm/action-setup@v2.0.1
+      name: Install pnpm
+      id: pnpm-install
+      with:
+        version: 7
+        run_install: false
+    - name: Get pnpm store directory
+      id: pnpm-cache
+      run: |
+        echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+    - uses: actions/cache@v3
+      name: Setup pnpm cache
+      with:
+        path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+    - name: Install dependencies
+      run: pnpm install
+    # run checks
+    - name: TypeScript checks
+      run: pnpm run checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       run: cargo check
     - name: Run clippy
       run: cargo clippy
-    - name: Run formatter
+    - name: Checking formatting
       run: cargo fmt --check
 
   typescript:


### PR DESCRIPTION
This setup will run on every push to your `main` branch. The two jobs (one each for the Rust and TypeScript code) run in parallel, and both make use of caching to speed up their runs, as requested.

I've commend-out the step to run clippy, as it's reporting warnings that fail the job. If you'd rather the violation report not cause the job to fail, let me know.

I explicitly use the TS type check commands in the two directories I see `tsconfig.json` files rather than running `pnpm run checks` at the top level, as that'd require the Rust setup in both jobs. That'd work, but I'd recommend collapsing the two jobs into one and forgoing the concurrency in favor of command simplicity.

Example run: https://github.com/Celeo/stump/actions/runs/3212770920

Fixes #68