### PR TITLE
Update GHA CI build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,9 @@ jobs:
     name: Run Rust checks
     runs-on: ubuntu-latest
     steps:
+      # setup
       - name: Checkout repository
         uses: actions/checkout@v3
-
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -22,25 +22,79 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      # TODO: Add caching
+      # caching
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
-      # This is a big pain without caching lol
+      # generate needed files
       - name: Generate Prisma client
         uses: ./.github/actions/generate-prisma-client
 
+      # run checks
       - name: Run cargo fmt
         run: |
           cargo fmt --all -- --check
-
       - name: Run clippy
         run: |
           export RUSTFLAGS="-C debuginfo=0"
-            cargo clippy --all-features
-            cargo clippy -- -D warnings
-
+          cargo clippy --all-features
+          cargo clippy -- -D warnings
       - name: Run tests
         run: |
           cargo integration-tests
+
+  check-typescript:
+    name: Run TypeScript checks
+    runs-on: ubuntu-latest
+    steps:
+      # setup
+      - uses: actions/checkout@v3
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - uses: pnpm/action-setup@v2.0.1
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 7
+          run_install: false
+
+      # caching
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: |
+          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - name: Install dependencies
+        run: pnpm install
+
+      # run checks
+      - name: TypeScript check for apps/client
+        run: pnpm tsc --noEmit
+        working-directory: apps/client
+      - name: TypeScript check for apps/website
+        run: pnpm tsc --noEmit
+        working-directory: apps/website
 
   release:
     name: Release (${{ matrix.platform }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,12 +89,10 @@ jobs:
         run: pnpm install
 
       # run checks
-      - name: TypeScript check for apps/client
-        run: pnpm tsc --noEmit
-        working-directory: apps/client
-      - name: TypeScript check for apps/website
-        run: pnpm tsc --noEmit
-        working-directory: apps/website
+      - run: pnpm tsc --noEmit
+        working-directory: common/client
+      - run: pnpm tsc --noEmit
+        working-directory: common/interface
 
   release:
     name: Release (${{ matrix.platform }})


### PR DESCRIPTION
This updates the existing build on push. The two jobs (one each for the Rust and TypeScript code) run in parallel, and both make use of caching to speed up their runs, as requested.

I explicitly use the TS type check commands in the two directories I see `tsconfig.json` files rather than running `pnpm run checks` at the top level, as that'd require the Rust setup in both jobs. That'd work, but I'd recommend collapsing the two jobs into one and forgoing the concurrency in favor of command simplicity.

Fixes #68

re: https://github.com/aaronleopold/stump/pull/71