### PR TITLE
docker: Allowing to downgrade to regular user via environment variables

### DIFF
--- a/scripts/release/Dockerfile
+++ b/scripts/release/Dockerfile
@@ -120,7 +120,7 @@ COPY --from=frontend /app/build ./app/client
 
 # Copy docker entrypoint
 # This will take care of starting the service daemon as a regular user, if desired
-COPY entrypoint.sh /entrypoint.sh
+COPY scripts/release/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # TODO: replace this with something more elegant lol maybe a bash case statement

--- a/scripts/release/Dockerfile
+++ b/scripts/release/Dockerfile
@@ -105,10 +105,6 @@ FROM alpine:latest
 # libc6-compat
 RUN apk add --no-cache libstdc++ binutils
 
-# Create the user/group for stump
-RUN addgroup -g 1000 stump
-RUN adduser -D -s /bin/sh -u 1000 -G stump stump
-
 WORKDIR /
 
 # create the config, data and app directories
@@ -116,19 +112,16 @@ RUN mkdir -p config && \
     mkdir -p data && \
     mkdir -p app
 
-# FIXME: this does not seem to be working...
-# make the stump user own the directories
-RUN chown stump /config && \
-    chown stump /data && \
-    chown stump /app
-
-USER stump
-
 # copy the binary
-COPY --chown=stump:stump --from=core-builder /app/stump ./app/stump
+COPY --from=core-builder /app/stump ./app/stump
 
 # copy the react build
 COPY --from=frontend /app/build ./app/client
+
+# Copy docker entrypoint
+# This will take care of starting the service daemon as a regular user, if desired
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 # TODO: replace this with something more elegant lol maybe a bash case statement
 RUN ln -s /lib/ld-musl-aarch64.so.1 /lib/ld-linux-aarch64.so.1; exit 0
@@ -144,4 +137,4 @@ ENV API_VERSION=v1
 
 WORKDIR /app
 
-CMD ["./stump"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/scripts/release/entrypoint.sh
+++ b/scripts/release/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Depending on the values passed for PUID/PGID via environment variables,
+# either starts the stump server daemon as root or as a regular user
+# 
+# Also takes care of assigning proper attributes to the folders /data, /config and /app
+PUID=${PUID:-0}
+PGID=${PGID:-0}
+
+USER=stump
+GROUP=stump
+
+## Add stump group if it doesn't already exist
+if [[ -z "$(getent group "$PGID" | cut -d':' -f1)" ]]; then
+    addgroup -g "$PGID" $GROUP
+fi
+
+## Add stump user if it doesn't already exist
+if [[ -z "$(getent passwd "$PUID" | cut -d':' -f1)" ]]; then
+    adduser -D -s /bin/sh -u "$PUID" -G "$GROUP" $USER
+fi
+
+# Change current working directory
+cd /app
+
+if [[ "$PUID" -eq 0 ]]; then
+    # Run as root
+    ./stump
+else
+    # Set ownership on config, app and data dir
+    chown -R "$PUID":"$PGID" /app
+    chown -R "$PUID":"$PGID" /config
+    # NOTE: Only change the directory itself, not recursively
+    # We dont want to accidentally overwrite with incorrect
+    # permissions if users provide wrong values for PUID/PGID
+    chown "$PUID":"$PGID" /data
+
+    # Run as non-root user
+    # NOTE: Omit "-l" switch to keep env vars
+    su $USER -c ./stump
+fi


### PR DESCRIPTION
This change implements an entrypoint-script for the docker container.

By passing environment variables `PUID=<numeric user id>` and `PGID=<numeric group id>` to the container, which is started as root by the docker daemon, can downgrade to the respective user and run the stump server daemon with lower privileges.

This also ensures that mounted directories/volumes are assigned and accessed with proper permissions.

**NOTE**: This essentially breaks the invocation via `--user` argument, currently documented on [Docker hub](https://hub.docker.com/r/aaronleopold/stump-preview)

- Fixes issue #56

Example docker compose

```yaml
version: '3.3'
services:
  stump:
    image: aaronleopold/stump-preview:latest
    container_name: stump
    volumes:
      - /home/user/.stump-config:/config
      - /media/books:/data
    ports:
      - 10801:10801
    environment:
      - PUID=1000
      - PGID=1000
    restart: unless-stopped
```

or via CLI

```
docker create \
  --name=stump \
  -e "PUID=1000" \
  -e "PGID=1000" \
  -p 6969:6969 \
  --mount type=bind,source=/Users/aaronleopold/.stump,target=/config \
  --mount type=bind,source=/Users/aaronleopold/Documents/Stump,target=/data \
  --restart unless-stopped \
  aaronleopold/stump-preview
```