### PR TITLE
feat: utoipa for openapi/swagger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4385,6 +4385,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "6.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "283ffe2f866869428c92e0d61c2f35dfb4355293cdfdc48f49e895c15f1333d1"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31ab23d42d71fb9be1b643fe6765d292c5e14d46912d13f3ae2815ca048ea04d"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.23",
+ "rust-embed-utils",
+ "shellexpand",
+ "syn 1.0.107",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "7.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1669d81dfabd1b5f8e2856b8bbe146c6192b0ba22162edc738ac0a5de18f054"
+dependencies = [
+ "sha2 0.10.6",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4813,6 +4848,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5145,6 +5189,7 @@ dependencies = [
  "trash",
  "unrar",
  "urlencoding",
+ "utoipa",
  "walkdir",
  "webp",
  "xml-rs",
@@ -5190,6 +5235,8 @@ dependencies = [
  "tokio-util",
  "tower-http",
  "tracing",
+ "utoipa",
+ "utoipa-swagger-ui",
 ]
 
 [[package]]
@@ -6096,6 +6143,46 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utoipa"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15f6da6a2b471134ca44b7d18e8a76d73035cf8b3ed24c4dd5ca6a63aa439c5"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f2e33027986a4707b3f5c37ed01b33d0e5a53da30204b52ff18f80600f1d0ec"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3d4f4da6408f0f20ff58196ed619c94306ab32635aeca3d3fa0768c0bd0de2"
+dependencies = [
+ "axum",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "utoipa",
+ "zip 0.6.3",
+]
 
 [[package]]
 name = "uuid"

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -36,6 +36,8 @@ local-ip-address = "0.5.1"
 
 ### Dev Utils ###
 rand = "0.8.5"
+utoipa = { version = "3.0.3", features = ["axum_extras"] }
+utoipa-swagger-ui = { version = "3.0.2", features = ["axum"] }
 
 ### Error Handling + Logging ###
 tracing = { workspace = true }

--- a/apps/server/src/errors.rs
+++ b/apps/server/src/errors.rs
@@ -11,6 +11,7 @@ use stump_core::{
 	prelude::{CoreError, ProcessFileError},
 };
 use tokio::sync::mpsc;
+use utoipa::ToSchema;
 
 use std::net;
 use thiserror::Error;
@@ -71,7 +72,7 @@ impl IntoResponse for AuthError {
 }
 
 #[allow(unused)]
-#[derive(Debug, Error)]
+#[derive(Debug, Error, ToSchema)]
 pub enum ApiError {
 	#[error("{0}")]
 	BadRequest(String),
@@ -94,6 +95,7 @@ pub enum ApiError {
 	#[error("{0}")]
 	Redirect(String),
 	#[error("{0}")]
+	#[schema(value_type = String)]
 	PrismaError(#[from] QueryError),
 }
 

--- a/apps/server/src/errors.rs
+++ b/apps/server/src/errors.rs
@@ -99,6 +99,14 @@ pub enum ApiError {
 	PrismaError(#[from] QueryError),
 }
 
+impl ApiError {
+	pub fn forbidden_discreet() -> ApiError {
+		ApiError::Forbidden(String::from(
+			"You do not have permission to access this resource.",
+		))
+	}
+}
+
 impl From<CoreError> for ApiError {
 	fn from(err: CoreError) -> Self {
 		match err {

--- a/apps/server/src/routers/api/mod.rs
+++ b/apps/server/src/routers/api/mod.rs
@@ -2,7 +2,7 @@ use axum::Router;
 
 use crate::config::state::AppState;
 
-mod v1;
+pub(crate) mod v1;
 
 pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
 	Router::new().nest("/api", Router::new().nest("/v1", v1::mount(app_state)))

--- a/apps/server/src/routers/api/v1/auth.rs
+++ b/apps/server/src/routers/api/v1/auth.rs
@@ -27,6 +27,17 @@ pub(crate) fn mount() -> Router<AppState> {
 	)
 }
 
+#[utoipa::path(
+	get,
+	path = "/api/v1/auth/me",
+	tag = "auth",
+	responses(
+		(status = 200, description = "Returns the currently logged in user from the session.", body = User),
+		(status = 401, description = "No user is logged in (unauthorized).")
+	)
+)]
+/// Returns the currently logged in user from the session. If no user is logged in, returns an
+/// unauthorized error.
 async fn viewer(session: ReadableSession) -> ApiResult<Json<User>> {
 	if let Some(user) = session.get::<User>("user") {
 		Ok(Json(user))
@@ -35,6 +46,18 @@ async fn viewer(session: ReadableSession) -> ApiResult<Json<User>> {
 	}
 }
 
+#[utoipa::path(
+	post,
+	path = "/api/v1/auth/login",
+	tag = "auth",
+	responses(
+		(status = 200, description = "Authenticates the user and returns the user object.", body = User),
+		(status = 401, description = "Invalid username or password."),
+		(status = 500, description = "An internal server error occurred.")
+	)
+)]
+/// Authenticates the user and returns the user object. If the user is already logged in, returns the
+/// user object from the session.
 async fn login(
 	mut session: WritableSession,
 	State(state): State<AppState>,
@@ -63,7 +86,7 @@ async fn login(
 		let user: User = db_user.into();
 		session
 			.insert("user", user.clone())
-			.expect("Failed to insert user into session");
+			.expect("Failed to write user to session");
 
 		return Ok(Json(user));
 	}
@@ -71,11 +94,38 @@ async fn login(
 	Err(ApiError::Unauthorized)
 }
 
+#[utoipa::path(
+	post,
+	path = "/api/v1/auth/logout",
+	tag = "auth",
+	responses(
+		(status = 200, description = "Destroys the session and logs the user out."),
+		(status = 500, description = "Failed to destroy session.")
+	)
+)]
+/// Destroys the session and logs the user out.
 async fn logout(mut session: WritableSession) -> ApiResult<()> {
 	session.destroy();
+	if !session.is_destroyed() {
+		return Err(ApiError::InternalServerError(
+			"Failed to destroy session".to_string(),
+		));
+	}
 	Ok(())
 }
 
+#[utoipa::path(
+	post,
+	path = "/api/v1/auth/register",
+	tag = "auth",
+	responses(
+		(status = 200, description = "Successfully registered new user.", body = User),
+		(status = 403, description = "Must be server owner to register member accounts."),
+		(status = 500, description = "An internal server error occurred.")
+	)
+)]
+/// Attempts to register a new user. If no users exist in the database, the user is registered as a server owner.
+/// Otherwise, the registration is rejected by all users except the server owner.
 pub async fn register(
 	session: ReadableSession,
 	State(ctx): State<AppState>,
@@ -87,13 +137,20 @@ pub async fn register(
 
 	let mut user_role = UserRole::default();
 
-	// server owners must register member accounts
-	if session.get::<User>("user").is_none() && has_users {
-		return Err(ApiError::Forbidden(
-			"Must be server owner to register member accounts".to_string(),
-		));
+	let session_user = session.get::<User>("user");
+
+	// TODO: move nested if to if let once stable
+	if let Some(user) = session_user {
+		if !user.is_admin() {
+			return Err(ApiError::Forbidden(String::from(
+				"You do not have permission to access this resource.",
+			)));
+		}
+	} else if session_user.is_none() && has_users {
+		// if users exist, a valid session is required to register a new user
+		return Err(ApiError::Unauthorized);
 	} else if !has_users {
-		// register the user as owner
+		// if no users present, the user is automatically a server owner
 		user_role = UserRole::ServerOwner;
 	}
 
@@ -119,7 +176,7 @@ pub async fn register(
 		.exec()
 		.await?;
 
-	// This *really* shouldn't fail, so I am using unwrap here. It also doesn't
+	// This *really* shouldn't fail, so I am using expect here. It also doesn't
 	// matter too much in the long run since this query will go away once above fixme
 	// is resolved.
 	let user = db
@@ -128,7 +185,7 @@ pub async fn register(
 		.with(user::user_preferences::fetch())
 		.exec()
 		.await?
-		.unwrap();
+		.expect("Failed to fetch user after registration.");
 
 	Ok(Json(user.into()))
 }

--- a/apps/server/src/routers/api/v1/auth.rs
+++ b/apps/server/src/routers/api/v1/auth.rs
@@ -50,6 +50,7 @@ async fn viewer(session: ReadableSession) -> ApiResult<Json<User>> {
 	post,
 	path = "/api/v1/auth/login",
 	tag = "auth",
+	request_body = LoginOrRegisterArgs,
 	responses(
 		(status = 200, description = "Authenticates the user and returns the user object.", body = User),
 		(status = 401, description = "Invalid username or password."),
@@ -118,6 +119,7 @@ async fn logout(mut session: WritableSession) -> ApiResult<()> {
 	post,
 	path = "/api/v1/auth/register",
 	tag = "auth",
+	request_body = LoginOrRegisterArgs,
 	responses(
 		(status = 200, description = "Successfully registered new user.", body = User),
 		(status = 403, description = "Must be server owner to register member accounts."),

--- a/apps/server/src/routers/api/v1/filesystem.rs
+++ b/apps/server/src/routers/api/v1/filesystem.rs
@@ -29,6 +29,10 @@ pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
 	post,
 	path = "/api/v1/filesystem",
 	tag = "filesystem",
+	request_body = Option<DirectoryListingInput>,
+	params(
+		("pagination" = Option<PageQuery>, Query, description = "Pagination parameters for the directory listing.")
+	),
 	responses(
 		(status = 200, description = "Successfully retrieved contents of directory", body = PageableDirectoryListing),
 		(status = 400, description = "Invalid request."),

--- a/apps/server/src/routers/api/v1/job.rs
+++ b/apps/server/src/routers/api/v1/job.rs
@@ -78,6 +78,9 @@ async fn delete_job_reports(State(ctx): State<AppState>) -> ApiResult<()> {
 	delete,
 	path = "/api/v1/jobs/:id/cancel",
 	tag = "job",
+	params(
+		("id" = String, Path, description = "The ID of the job to cancel.")
+	),
 	responses(
 		(status = 200, description = "Successfully cancelled job"),
 		(status = 401, description = "No user is logged in (unauthorized)."),

--- a/apps/server/src/routers/api/v1/job.rs
+++ b/apps/server/src/routers/api/v1/job.rs
@@ -26,6 +26,17 @@ pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
 		.layer(from_extractor_with_state::<Auth, AppState>(app_state))
 }
 
+#[utoipa::path(
+	get,
+	path = "/api/v1/jobs",
+	tag = "job",
+	responses(
+		(status = 200, description = "Successfully retrieved job reports", body = [JobReport]),
+		(status = 401, description = "No user is logged in (unauthorized)."),
+		(status = 403, description = "User does not have permission to access this resource."),
+		(status = 500, description = "Internal server error."),
+	)
+)]
 /// Get all running/pending jobs.
 async fn get_job_reports(State(ctx): State<AppState>) -> ApiResult<Json<Vec<JobReport>>> {
 	let (task_tx, task_rx) = oneshot::channel();
@@ -45,12 +56,36 @@ async fn get_job_reports(State(ctx): State<AppState>) -> ApiResult<Json<Vec<JobR
 	Ok(Json(res))
 }
 
+#[utoipa::path(
+	delete,
+	path = "/api/v1/jobs",
+	tag = "job",
+	responses(
+		(status = 200, description = "Successfully deleted job reports"),
+		(status = 401, description = "No user is logged in (unauthorized)."),
+		(status = 403, description = "User does not have permission to access this resource."),
+		(status = 500, description = "Internal server error."),
+	)
+)]
+/// Delete all job reports.
 async fn delete_job_reports(State(ctx): State<AppState>) -> ApiResult<()> {
 	let result = ctx.db.job().delete_many(vec![]).exec().await?;
 	debug!("Deleted {} job reports", result);
 	Ok(())
 }
 
+#[utoipa::path(
+	delete,
+	path = "/api/v1/jobs/:id/cancel",
+	tag = "job",
+	responses(
+		(status = 200, description = "Successfully cancelled job"),
+		(status = 401, description = "No user is logged in (unauthorized)."),
+		(status = 403, description = "User does not have permission to access this resource."),
+		(status = 500, description = "Internal server error."),
+	)
+)]
+/// Cancel a running job. This will not delete the job report.
 async fn cancel_job(
 	State(ctx): State<AppState>,
 	Path(job_id): Path<String>,

--- a/apps/server/src/routers/api/v1/library.rs
+++ b/apps/server/src/routers/api/v1/library.rs
@@ -78,8 +78,8 @@ pub(crate) fn apply_library_filters(filters: LibraryFilter) -> Vec<WhereParam> {
 	path = "/api/v1/libraries",
 	tag = "library",
 	params(
-		("filter_query" = FilterableLibraryQuery, Query, description = "The library filters"),
-		("pagination_query" = PaginationQuery, Query, description = "The pagination options")
+		("filter_query" = Option<FilterableLibraryQuery>, Query, description = "The library filters"),
+		("pagination_query" = Option<PaginationQuery>, Query, description = "The pagination options")
 	),
 	responses(
 		(status = 200, description = "Successfully retrieved libraries", body = PageableLibraries),
@@ -230,8 +230,8 @@ async fn get_library_by_id(
 	tag = "library",
 	params(
 		("id" = String, Path, description = "The library ID"),
-		("filter_query" = FilterableLibraryQuery, Query, description = "The library filters"),
-		("pagination_query" = PaginationQuery, Query, description = "The pagination options")
+		("filter_query" = Option<FilterableLibraryQuery>, Query, description = "The library filters"),
+		("pagination_query" = Option<PaginationQuery>, Query, description = "The pagination options")
 	),
 	responses(
 		(status = 200, description = "Successfully retrieved series", body = PageableSeries),

--- a/apps/server/src/routers/api/v1/library.rs
+++ b/apps/server/src/routers/api/v1/library.rs
@@ -73,6 +73,16 @@ pub(crate) fn apply_library_filters(filters: LibraryFilter) -> Vec<WhereParam> {
 	_where
 }
 
+#[utoipa::path(
+	get,
+	path = "/api/v1/libraries",
+	tag = "library",
+	responses(
+		(status = 200, description = "Successfully retrieved libraries", body = PageableLibraries),
+		(status = 401, description = "Unauthorized"),
+		(status = 500, description = "Internal server error")
+	)
+)]
 /// Get all libraries
 #[tracing::instrument(skip(ctx), err)]
 async fn get_libraries(
@@ -129,6 +139,16 @@ async fn get_libraries(
 	Ok(Json((libraries, count, pagination).into()))
 }
 
+#[utoipa::path(
+	get,
+	path = "/api/v1/libraries/stats",
+	tag = "library",
+	responses(
+		(status = 200, description = "Successfully fetched stats", body = LibrariesStats),
+		(status = 401, description = "Unauthorized"),
+		(status = 500, description = "Internal server error")
+	)
+)]
 /// Get stats for all libraries
 async fn get_libraries_stats(
 	State(ctx): State<AppState>,
@@ -154,6 +174,17 @@ async fn get_libraries_stats(
 	Ok(Json(stats.unwrap()))
 }
 
+#[utoipa::path(
+	get,
+	path = "/api/v1/libraries/:id",
+	tag = "library",
+	responses(
+		(status = 200, description = "Successfully retrieved library", body = Library),
+		(status = 401, description = "Unauthorized"),
+		(status = 404, description = "Library not found"),
+		(status = 500, description = "Internal server error")
+	)
+)]
 /// Get a library by id, if the current user has access to it. Library `series`, `media`
 /// and `tags` relations are loaded on this route.
 async fn get_library_by_id(
@@ -186,6 +217,17 @@ async fn get_library_by_id(
 	Ok(Json(library.into()))
 }
 
+#[utoipa::path(
+	get,
+	path = "/api/v1/libraries/:id/series",
+	tag = "library",
+	responses(
+		(status = 200, description = "Successfully retrieved series", body = PageableSeries),
+		(status = 401, description = "Unauthorized"),
+		(status = 404, description = "Library not found"),
+		(status = 500, description = "Internal server error")
+	)
+)]
 // FIXME: this is absolutely atrocious...
 // This should be much better once https://github.com/Brendonovich/prisma-client-rust/issues/24 is added
 // but for now I will have this disgustingly gross and ugly work around...
@@ -257,7 +299,19 @@ async fn get_library_series(
 	Ok(Json((series, series_count, pagination).into()))
 }
 
-// /// Get the thumbnail image for a library by id, if the current user has access to it.
+// TODO: ImageResponse for utoipa
+#[utoipa::path(
+	get,
+	path = "/api/v1/libraries/:id/thumbnail",
+	tag = "library",
+	responses(
+		(status = 200, description = "Successfully retrieved library thumbnail"),
+		(status = 401, description = "Unauthorized"),
+		(status = 404, description = "Library not found"),
+		(status = 500, description = "Internal server error")
+	)
+)]
+/// Get the thumbnail image for a library by id, if the current user has access to it.
 async fn get_library_thumbnail(
 	Path(id): Path<String>,
 	State(ctx): State<AppState>,
@@ -272,10 +326,8 @@ async fn get_library_thumbnail(
 		.await?;
 
 	// TODO: error handling
-
-	let series = library_series.first().unwrap();
-
-	let media = series.media()?.first().unwrap();
+	let series = library_series.first().expect("No series in library");
+	let media = series.media()?.first().expect("No media in series");
 
 	Ok(media_file::get_page(media.path.as_str(), 1)?.into())
 }
@@ -285,6 +337,17 @@ struct ScanQueryParam {
 	scan_mode: Option<String>,
 }
 
+#[utoipa::path(
+	post,
+	path = "/api/v1/libraries/:id/scan",
+	tag = "library",
+	responses(
+		(status = 200, description = "Successfully queued library scan"),
+		(status = 401, description = "Unauthorized"),
+		(status = 404, description = "Library not found"),
+		(status = 500, description = "Internal server error")
+	)
+)]
 /// Queue a ScannerJob to scan the library by id. The job, when started, is
 /// executed in a separate thread.
 async fn scan_library(
@@ -328,11 +391,26 @@ async fn scan_library(
 	Ok(())
 }
 
+#[utoipa::path(
+	post,
+	path = "/api/v1/libraries",
+	tag = "library",
+	responses(
+		(status = 200, description = "Successfully created library"),
+		(status = 400, description = "Bad request"),
+		(status = 401, description = "Unauthorized"),
+		(status = 403, description = "Forbidden"),
+		(status = 500, description = "Internal server error")
+	)
+)]
 /// Create a new library. Will queue a ScannerJob to scan the library, and return the library
 async fn create_library(
+	session: ReadableSession,
 	State(ctx): State<AppState>,
 	Json(input): Json<CreateLibraryArgs>,
 ) -> ApiResult<Json<Library>> {
+	get_session_admin_user(&session)?;
+
 	let db = ctx.get_db();
 
 	if !path::Path::new(&input.path).exists() {
@@ -407,10 +485,9 @@ async fn create_library(
 			Ok(Library::from(library))
 		})
 		.await;
+
 	let library = transaction_result?;
-
 	let scan_mode = input.scan_mode.unwrap_or_default();
-
 	// `scan` is not a required field, however it will default to BATCHED if not provided
 	if scan_mode != LibraryScanMode::None {
 		ctx.spawn_job(Box::new(LibraryScanJob {
@@ -422,12 +499,27 @@ async fn create_library(
 	Ok(Json(library))
 }
 
+#[utoipa::path(
+	put,
+	path = "/api/v1/libraries/:id",
+	tag = "library",
+	responses(
+		(status = 200, description = "Successfully updated library"),
+		(status = 400, description = "Bad request"),
+		(status = 401, description = "Unauthorized"),
+		(status = 403, description = "Forbidden"),
+		(status = 404, description = "Not found"),
+		(status = 500, description = "Internal server error")
+	)
+)]
 /// Update a library by id, if the current user is a SERVER_OWNER.
 async fn update_library(
+	session: ReadableSession,
 	State(ctx): State<AppState>,
 	Path(id): Path<String>,
 	Json(input): Json<UpdateLibraryArgs>,
 ) -> ApiResult<Json<Library>> {
+	get_session_admin_user(&session)?;
 	let db = ctx.get_db();
 
 	if !path::Path::new(&input.path).exists() {
@@ -517,11 +609,26 @@ async fn update_library(
 	Ok(Json(updated.into()))
 }
 
-/// Delete a library by id, if the current user is a SERVER_OWNER.
+#[utoipa::path(
+	delete,
+	path = "/api/v1/libraries/:id",
+	tag = "library",
+	responses(
+		(status = 200, description = "Successfully deleted library"),
+		(status = 400, description = "Bad request"),
+		(status = 401, description = "Unauthorized"),
+		(status = 403, description = "Forbidden"),
+		(status = 404, description = "Not found"),
+		(status = 500, description = "Internal server error")
+	)
+)]
+/// Delete a library by id
 async fn delete_library(
+	session: ReadableSession,
 	Path(id): Path<String>,
 	State(ctx): State<AppState>,
 ) -> ApiResult<Json<String>> {
+	get_session_admin_user(&session)?;
 	let db = ctx.get_db();
 
 	trace!(?id, "Attempting to delete library");

--- a/apps/server/src/routers/api/v1/mod.rs
+++ b/apps/server/src/routers/api/v1/mod.rs
@@ -7,17 +7,17 @@ use stump_core::prelude::{ClaimResponse, StumpVersion};
 
 use crate::{config::state::AppState, errors::ApiResult};
 
-mod auth;
-mod epub;
-mod filesystem;
-mod job;
-mod library;
-mod log;
-mod media;
-mod reading_list;
-mod series;
-mod tag;
-mod user;
+pub(crate) mod auth;
+pub(crate) mod epub;
+pub(crate) mod filesystem;
+pub(crate) mod job;
+pub(crate) mod library;
+pub(crate) mod log;
+pub(crate) mod media;
+pub(crate) mod reading_list;
+pub(crate) mod series;
+pub(crate) mod tag;
+pub(crate) mod user;
 
 pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
 	Router::new()
@@ -37,6 +37,14 @@ pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
 		.route("/version", post(version))
 }
 
+#[utoipa::path(
+	get,
+	path = "/api/v1/claim",
+	tag = "util",
+	responses(
+		(status = 200, description = "Claim status successfully determined", body = ClaimResponse)
+	)
+)]
 async fn claim(State(ctx): State<AppState>) -> ApiResult<Json<ClaimResponse>> {
 	let db = ctx.get_db();
 
@@ -45,10 +53,26 @@ async fn claim(State(ctx): State<AppState>) -> ApiResult<Json<ClaimResponse>> {
 	}))
 }
 
+#[utoipa::path(
+	get,
+	path = "/api/v1/ping",
+	tag = "util",
+	responses(
+		(status = 200, description = "Always responds with 'pong'", body = String)
+	)
+)]
 async fn ping() -> ApiResult<String> {
 	Ok("pong".to_string())
 }
 
+#[utoipa::path(
+	post,
+	path = "/api/v1/version",
+	tag = "util",
+	responses(
+		(status = 200, description = "Version information for the Stump server instance", body = StumpVersion)
+	)
+)]
 async fn version() -> ApiResult<Json<StumpVersion>> {
 	Ok(Json(StumpVersion {
 		semver: env!("CARGO_PKG_VERSION").to_string(),

--- a/apps/server/src/routers/api/v1/reading_list.rs
+++ b/apps/server/src/routers/api/v1/reading_list.rs
@@ -33,6 +33,18 @@ pub(crate) fn mount() -> Router<AppState> {
 		)
 }
 
+#[utoipa::path(
+	get,
+	path = "/api/v1/reading-list",
+	tag = "reading-list",
+	responses(
+		(status = 200, description = "Successfully fetched reading lists.", body = [ReadingList]),
+		(status = 401, description = "Unauthorized."),
+		(status = 500, description = "Internal server error."),
+	)
+)]
+// TODO: pagination
+/// Fetches all reading lists for the current user.
 async fn get_reading_list(
 	State(ctx): State<AppState>,
 	session: ReadableSession,
@@ -51,6 +63,17 @@ async fn get_reading_list(
 	))
 }
 
+#[utoipa::path(
+	post,
+	path = "/api/v1/reading-list",
+	tag = "reading-list",
+	request_body = CreateReadingList,
+	responses(
+		(status = 200, description = "Successfully created reading list.", body = ReadingList),
+		(status = 401, description = "Unauthorized."),
+		(status = 500, description = "Internal server error."),
+	)
+)]
 async fn create_reading_list(
 	State(ctx): State<AppState>,
 	session: ReadableSession,
@@ -78,6 +101,20 @@ async fn create_reading_list(
 	Ok(Json(created_reading_list.into()))
 }
 
+#[utoipa::path(
+	get,
+	path = "/api/v1/reading-list/:id",
+	tag = "reading-list",
+	params(
+		("id" = String, Path, description = "The ID of the reading list to fetch.")
+	),
+	responses(
+		(status = 200, description = "Successfully fetched reading list.", body = ReadingList),
+		(status = 401, description = "Unauthorized."),
+		(status = 404, description = "Reading list not found."),
+		(status = 500, description = "Internal server error."),
+	)
+)]
 async fn get_reading_list_by_id(
 	Path(id): Path<String>,
 	State(ctx): State<AppState>,
@@ -86,13 +123,13 @@ async fn get_reading_list_by_id(
 	let _user_id = get_session_user(&session)?.id;
 	let db = ctx.get_db();
 
-	let reading_list_id = db
+	let reading_list = db
 		.reading_list()
 		.find_unique(reading_list::id::equals(id.clone()))
 		.exec()
 		.await?;
 
-	if reading_list_id.is_none() {
+	if reading_list.is_none() {
 		return Err(ApiError::NotFound(format!(
 			"Reading List with id {} not found",
 			id
@@ -100,18 +137,57 @@ async fn get_reading_list_by_id(
 	}
 
 	// TODO: access control for reading lists...
-
-	Ok(Json(reading_list_id.unwrap().into()))
+	Ok(Json(reading_list.unwrap().into()))
 }
 
+// TODO: fix this endpoint, way too naive of an update...
+#[utoipa::path(
+	put,
+	path = "/api/v1/reading-list/:id",
+	tag = "reading-list",
+	params(
+		("id" = String, Path, description = "The ID of the reading list to update.")
+	),
+	request_body = CreateReadingList,
+	responses(
+		(status = 200, description = "Successfully updated reading list.", body = ReadingList),
+		(status = 401, description = "Unauthorized."),
+		(status = 403, description = "Forbidden."),
+		(status = 404, description = "Reading list not found."),
+		(status = 500, description = "Internal server error."),
+	)
+)]
 async fn update_reading_list(
+	session: ReadableSession,
 	Path(id): Path<String>,
 	State(ctx): State<AppState>,
 	Json(input): Json<CreateReadingList>,
 ) -> ApiResult<Json<ReadingList>> {
+	let user = get_session_user(&session)?;
 	let db = ctx.get_db();
 
-	let created_reading_list: _ = db
+	let reading_list = db
+		.reading_list()
+		.find_unique(reading_list::id::equals(id.clone()))
+		.exec()
+		.await?;
+
+	if reading_list.is_none() {
+		return Err(ApiError::NotFound(format!(
+			"Reading List with id {} not found",
+			id
+		)));
+	}
+
+	let reading_list = reading_list.unwrap();
+	if reading_list.creating_user_id != user.id {
+		// TODO: log bad access attempt to DB
+		return Err(ApiError::Forbidden(String::from(
+			"You do not have permission to access this resource.",
+		)));
+	}
+
+	let created_reading_list = db
 		.reading_list()
 		.update(
 			reading_list::id::equals(id.clone()),
@@ -129,19 +205,54 @@ async fn update_reading_list(
 	Ok(Json(created_reading_list.into()))
 }
 
+#[utoipa::path(
+	delete,
+	path = "/api/v1/reading-list/:id",
+	tag = "reading-list",
+	params(
+		("id" = String, Path, description = "The ID of the reading list to delete.")
+	),
+	responses(
+		(status = 200, description = "Successfully deleted reading list.", body = ReadingList),
+		(status = 401, description = "Unauthorized."),
+		(status = 403, description = "Forbidden."),
+		(status = 404, description = "Reading list not found."),
+		(status = 500, description = "Internal server error."),
+	)
+)]
 async fn delete_reading_list_by_id(
+	session: ReadableSession,
 	Path(id): Path<String>,
 	State(ctx): State<AppState>,
-) -> ApiResult<Json<String>> {
+) -> ApiResult<Json<ReadingList>> {
+	let user = get_session_user(&session)?;
 	let db = ctx.get_db();
 
-	trace!("Attempting to delete reading list with ID {}", &id);
+	let reading_list = db
+		.reading_list()
+		.find_unique(reading_list::id::equals(id.clone()))
+		.exec()
+		.await?;
 
+	if reading_list.is_none() {
+		return Err(ApiError::NotFound(format!(
+			"Reading List with id {} not found",
+			id
+		)));
+	}
+
+	let reading_list = reading_list.unwrap();
+	if reading_list.creating_user_id != user.id {
+		// TODO: log bad access attempt to DB
+		return Err(ApiError::forbidden_discreet());
+	}
+
+	trace!("Attempting to delete reading list with ID {}", &id);
 	let deleted = db
 		.reading_list()
 		.delete(reading_list::id::equals(id.clone()))
 		.exec()
 		.await?;
 
-	Ok(Json(deleted.id))
+	Ok(Json(deleted.into()))
 }

--- a/apps/server/src/routers/api/v1/tag.rs
+++ b/apps/server/src/routers/api/v1/tag.rs
@@ -19,7 +19,7 @@ pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
 #[utoipa::path(
 	get,
 	path = "/api/v1/tags",
-	tag = "tags",
+	tag = "tag",
 	responses(
 		(status = 200, description = "Successfully fetched tags.", body = [Tag]),
 		(status = 401, description = "Unauthorized."),
@@ -45,7 +45,7 @@ async fn get_tags(State(ctx): State<AppState>) -> ApiResult<Json<Vec<Tag>>> {
 #[utoipa::path(
 	post,
 	path = "/api/v1/tags",
-	tag = "tags",
+	tag = "tag",
 	request_body = CreateTags,
 	responses(
 		(status = 200, description = "Successfully created tags.", body = [Tag]),

--- a/apps/server/src/routers/api/v1/tag.rs
+++ b/apps/server/src/routers/api/v1/tag.rs
@@ -1,10 +1,14 @@
 use axum::{
 	extract::State, middleware::from_extractor_with_state, routing::get, Json, Router,
 };
-use serde::Deserialize;
-use stump_core::db::models::Tag;
+use stump_core::{db::models::Tag, prelude::CreateTags, prisma::tag};
+use tracing::error;
 
-use crate::{config::state::AppState, errors::ApiResult, middleware::auth::Auth};
+use crate::{
+	config::state::AppState,
+	errors::{ApiError, ApiResult},
+	middleware::auth::Auth,
+};
 
 pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
 	Router::new()
@@ -12,6 +16,16 @@ pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
 		.layer(from_extractor_with_state::<Auth, AppState>(app_state))
 }
 
+#[utoipa::path(
+	get,
+	path = "/api/v1/tags",
+	tag = "tags",
+	responses(
+		(status = 200, description = "Successfully fetched tags.", body = [Tag]),
+		(status = 401, description = "Unauthorized."),
+		(status = 500, description = "Internal server error."),
+	)
+)]
 /// Get all tags for all items in the database. Tags are returned in a flat list,
 /// not grouped by the items which they belong to.
 async fn get_tags(State(ctx): State<AppState>) -> ApiResult<Json<Vec<Tag>>> {
@@ -23,43 +37,56 @@ async fn get_tags(State(ctx): State<AppState>) -> ApiResult<Json<Vec<Tag>>> {
 			.exec()
 			.await?
 			.into_iter()
-			.map(|t| t.into())
+			.map(Tag::from)
 			.collect(),
 	))
 }
 
-#[derive(Deserialize)]
-pub struct CreateTags {
-	pub tags: Vec<String>,
-}
-
+#[utoipa::path(
+	post,
+	path = "/api/v1/tags",
+	tag = "tags",
+	request_body = CreateTags,
+	responses(
+		(status = 200, description = "Successfully created tags.", body = [Tag]),
+		(status = 401, description = "Unauthorized."),
+		(status = 500, description = "Internal server error."),
+	)
+)]
+/// Create new tags. If any of the tags already exist, an error is returned.
 async fn create_tags(
 	State(ctx): State<AppState>,
 	Json(input): Json<CreateTags>,
 ) -> ApiResult<Json<Vec<Tag>>> {
 	let db = ctx.get_db();
 
-	let tags = input.tags.to_owned();
+	let already_existing_tags = db
+		.tag()
+		.find_many(vec![tag::name::in_vec(input.tags.clone())])
+		.exec()
+		.await?;
 
-	let mut created_tags = vec![];
+	if !already_existing_tags.is_empty() {
+		error!(existing_tags = ?already_existing_tags, "Tags already exist");
 
-	// FIXME: bulk insert not yet supported. Also transactions, as an alternative,
-	// not yet supported.
-	for tag in tags {
-		match db.tag().create(tag, vec![]).exec().await {
-			Ok(new_tag) => {
-				created_tags.push(new_tag.into());
-			},
-			Err(e) => {
-				// TODO: check if duplicate tag error, in which case I don't care and
-				// will ignore the error, otherwise throw the error.
-				// Alternative, I could upsert? This way an error is always an error,
-				// and if there's a duplicate tag it will be "updated", but really nothing
-				// will happen sine the name is the same?
-				println!("{}", e);
-			},
-		}
+		let existing_names = already_existing_tags
+			.into_iter()
+			.map(|t| t.name)
+			.collect::<Vec<String>>()
+			.join(", ");
+
+		return Err(ApiError::BadRequest(format!(
+			"Attempted to create tags which already exist: {}",
+			existing_names
+		)));
 	}
 
-	Ok(Json(created_tags))
+	let create_tags = input
+		.tags
+		.into_iter()
+		.map(|value| db.tag().create(value, vec![]))
+		.collect::<Vec<_>>();
+	let created_tags = db._batch(create_tags).await?;
+
+	Ok(Json(created_tags.into_iter().map(Tag::from).collect()))
 }

--- a/apps/server/src/routers/mod.rs
+++ b/apps/server/src/routers/mod.rs
@@ -1,6 +1,8 @@
+use std::env;
+
 use axum::Router;
 
-use crate::config::state::AppState;
+use crate::config::{state::AppState, utils::is_debug};
 
 mod api;
 mod opds;
@@ -10,8 +12,15 @@ mod utoipa;
 mod ws;
 
 pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
-	Router::new()
-		.merge(utoipa::swagger_ui())
+	let mut app_router = Router::new();
+
+	if let Ok(flag) = env::var("ENABLE_SWAGGER_UI") {
+		if flag != "false" || is_debug() {
+			app_router = app_router.merge(utoipa::swagger_ui());
+		}
+	}
+
+	app_router
 		.merge(spa::mount())
 		.merge(ws::mount())
 		.merge(sse::mount())

--- a/apps/server/src/routers/mod.rs
+++ b/apps/server/src/routers/mod.rs
@@ -14,10 +14,10 @@ mod ws;
 pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
 	let mut app_router = Router::new();
 
-	if let Ok(flag) = env::var("ENABLE_SWAGGER_UI") {
-		if flag != "false" || is_debug() {
-			app_router = app_router.merge(utoipa::swagger_ui());
-		}
+	let enable_swagger =
+		env::var("ENABLE_SWAGGER_UI").unwrap_or_else(|_| String::from("true"));
+	if enable_swagger != "false" || is_debug() {
+		app_router = app_router.merge(utoipa::swagger_ui());
 	}
 
 	app_router

--- a/apps/server/src/routers/mod.rs
+++ b/apps/server/src/routers/mod.rs
@@ -6,10 +6,12 @@ mod api;
 mod opds;
 mod spa;
 mod sse;
+mod utoipa;
 mod ws;
 
 pub(crate) fn mount(app_state: AppState) -> Router<AppState> {
 	Router::new()
+		.merge(utoipa::swagger_ui())
 		.merge(spa::mount())
 		.merge(ws::mount())
 		.merge(sse::mount())

--- a/apps/server/src/routers/utoipa.rs
+++ b/apps/server/src/routers/utoipa.rs
@@ -4,8 +4,8 @@ use stump_core::db::models::{
 };
 use stump_core::job::{JobReport, JobStatus};
 use stump_core::prelude::{
-	ClaimResponse, CreateLibraryArgs, CreateReadingList, CursorInfo, Direction,
-	DirectoryListing, DirectoryListingFile, DirectoryListingInput, FileStatus,
+	ClaimResponse, CreateLibraryArgs, CreateReadingList, CreateTags, CursorInfo,
+	Direction, DirectoryListing, DirectoryListingFile, DirectoryListingInput, FileStatus,
 	LoginOrRegisterArgs, PageInfo, PageQuery, PageableDirectoryListing,
 	PageableLibraries, PageableMedia, PageableSeries, PaginationQuery, QueryOrder,
 	ScanQueryParam, StumpVersion, UpdateLibraryArgs, UpdateUserArgs,
@@ -68,6 +68,8 @@ use super::api;
         api::v1::series::get_recently_added_series,
         api::v1::series::get_series_thumbnail,
         api::v1::series::get_series_media,
+        api::v1::tag::get_tags,
+        api::v1::tag::create_tags,
         api::v1::series::get_next_in_series,
         api::v1::user::get_users,
         api::v1::user::create_user,
@@ -87,7 +89,8 @@ use super::api;
             PageQuery, FilterableLibraryQuery, PaginationQuery, QueryOrder, LibraryFilter,
             Direction, CreateLibraryArgs, UpdateLibraryArgs, ApiError, MediaFilter, SeriesFilter,
             FilterableMediaQuery, FilterableSeriesQuery, JobReport, LibrariesStats, ScanQueryParam,
-            JobStatus, SeriesRelation, CreateReadingList, UserPreferencesUpdate, UpdateUserArgs
+            JobStatus, SeriesRelation, CreateReadingList, UserPreferencesUpdate, UpdateUserArgs,
+            CreateTags
         )
     ),
     tags(

--- a/apps/server/src/routers/utoipa.rs
+++ b/apps/server/src/routers/utoipa.rs
@@ -1,14 +1,23 @@
 use stump_core::db::models::{
-	Library, LibraryOptions, LibraryPattern, LibraryScanMode, LogLevel, Media,
-	ReadProgress, ReadingList, Series, Tag, User, UserPreferences,
+	LibrariesStats, Library, LibraryOptions, LibraryPattern, LibraryScanMode, LogLevel,
+	Media, ReadProgress, ReadingList, Series, Tag, User, UserPreferences,
 };
+use stump_core::job::{JobReport, JobStatus};
 use stump_core::prelude::{
-	ClaimResponse, CursorInfo, DirectoryListing, DirectoryListingFile, FileStatus,
-	PageInfo, PageableDirectoryListing, PageableLibraries, PageableMedia, PageableSeries,
-	StumpVersion,
+	ClaimResponse, CreateLibraryArgs, CursorInfo, Direction, DirectoryListing,
+	DirectoryListingFile, DirectoryListingInput, FileStatus, LoginOrRegisterArgs,
+	PageInfo, PageQuery, PageableDirectoryListing, PageableLibraries, PageableMedia,
+	PageableSeries, PaginationQuery, QueryOrder, ScanQueryParam, StumpVersion,
+	UpdateLibraryArgs,
 };
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
+
+use crate::errors::ApiError;
+use crate::utils::{
+	FilterableLibraryQuery, FilterableMediaQuery, FilterableSeriesQuery, LibraryFilter,
+	MediaFilter, SeriesFilter,
+};
 
 use super::api;
 
@@ -38,6 +47,16 @@ use super::api;
         api::v1::library::create_library,
         api::v1::library::update_library,
         api::v1::library::delete_library,
+        api::v1::media::get_media,
+        api::v1::media::get_duplicate_media,
+        api::v1::media::get_in_progress_media,
+        api::v1::media::get_recently_added_media,
+        api::v1::media::get_media_by_id,
+        api::v1::media::get_media_file,
+        api::v1::media::convert_media,
+        api::v1::media::get_media_page,
+        api::v1::media::get_media_thumbnail,
+        api::v1::media::update_media_progress,
     ),
     components(
         schemas(
@@ -45,7 +64,11 @@ use super::api;
             UserPreferences, LibraryPattern, LibraryScanMode, LogLevel, ClaimResponse,
             StumpVersion, FileStatus, PageableDirectoryListing, DirectoryListing,
             DirectoryListingFile, CursorInfo, PageInfo, PageableLibraries,
-            PageableMedia, PageableSeries
+            PageableMedia, PageableSeries, LoginOrRegisterArgs, DirectoryListingInput,
+            PageQuery, FilterableLibraryQuery, PaginationQuery, QueryOrder, LibraryFilter,
+            Direction, CreateLibraryArgs, UpdateLibraryArgs, ApiError, MediaFilter, SeriesFilter,
+            FilterableMediaQuery, FilterableSeriesQuery, JobReport, LibrariesStats, ScanQueryParam,
+            JobStatus
         )
     ),
     tags(

--- a/apps/server/src/routers/utoipa.rs
+++ b/apps/server/src/routers/utoipa.rs
@@ -103,6 +103,7 @@ use super::api;
         (name = "media", description = "Media API"),
         (name = "series", description = "Series API"),
         (name = "tag", description = "Tag API"),
+        (name = "reading-list", description = "Reading List API"),
         (name = "user", description = "User API"),
         (name = "opds", description = "OPDS API"),
     )

--- a/apps/server/src/routers/utoipa.rs
+++ b/apps/server/src/routers/utoipa.rs
@@ -1,0 +1,69 @@
+use stump_core::db::models::{
+	Library, LibraryOptions, LibraryPattern, LibraryScanMode, LogLevel, Media,
+	ReadProgress, ReadingList, Series, Tag, User, UserPreferences,
+};
+use stump_core::prelude::{
+	ClaimResponse, CursorInfo, DirectoryListing, DirectoryListingFile, FileStatus,
+	PageInfo, PageableDirectoryListing, PageableLibraries, PageableMedia, PageableSeries,
+	StumpVersion,
+};
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
+
+use super::api;
+
+// NOTE: it is very easy to indirectly cause fmt failures by not adhering to the
+// rustfmt rules, since cargo fmt will not format the code in the macro.
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        api::v1::claim,
+        api::v1::ping,
+        api::v1::version,
+        api::v1::auth::viewer,
+        api::v1::auth::login,
+        api::v1::auth::logout,
+        api::v1::auth::register,
+        // TODO: epub here
+        api::v1::filesystem::list_directory,
+        api::v1::job::get_job_reports,
+        api::v1::job::delete_job_reports,
+        api::v1::job::cancel_job,
+        api::v1::library::get_libraries,
+        api::v1::library::get_libraries_stats,
+        api::v1::library::get_library_by_id,
+        api::v1::library::get_library_series,
+        api::v1::library::get_library_thumbnail,
+        api::v1::library::scan_library,
+        api::v1::library::create_library,
+        api::v1::library::update_library,
+        api::v1::library::delete_library,
+    ),
+    components(
+        schemas(
+            Library, LibraryOptions, Media, ReadingList, ReadProgress, Series, Tag, User,
+            UserPreferences, LibraryPattern, LibraryScanMode, LogLevel, ClaimResponse,
+            StumpVersion, FileStatus, PageableDirectoryListing, DirectoryListing,
+            DirectoryListingFile, CursorInfo, PageInfo, PageableLibraries,
+            PageableMedia, PageableSeries
+        )
+    ),
+    tags(
+        (name = "util", description = "Utility API"),
+        (name = "auth", description = "Authentication API"),
+        (name = "epub", description = "EPUB API"),
+        (name = "filesystem", description = "Filesystem API"),
+        (name = "job", description = "Job API"),
+        (name = "library", description = "Library API"),
+        (name = "media", description = "Media API"),
+        (name = "series", description = "Series API"),
+        (name = "tag", description = "Tag API"),
+        (name = "user", description = "User API"),
+        (name = "opds", description = "OPDS API"),
+    )
+)]
+struct ApiDoc;
+
+pub(crate) fn swagger_ui() -> SwaggerUi {
+	SwaggerUi::new("/swagger-ui").url("/api-doc/openapi.json", ApiDoc::openapi())
+}

--- a/apps/server/src/routers/utoipa.rs
+++ b/apps/server/src/routers/utoipa.rs
@@ -4,11 +4,12 @@ use stump_core::db::models::{
 };
 use stump_core::job::{JobReport, JobStatus};
 use stump_core::prelude::{
-	ClaimResponse, CreateLibraryArgs, CursorInfo, Direction, DirectoryListing,
-	DirectoryListingFile, DirectoryListingInput, FileStatus, LoginOrRegisterArgs,
-	PageInfo, PageQuery, PageableDirectoryListing, PageableLibraries, PageableMedia,
-	PageableSeries, PaginationQuery, QueryOrder, ScanQueryParam, StumpVersion,
-	UpdateLibraryArgs,
+	ClaimResponse, CreateLibraryArgs, CreateReadingList, CursorInfo, Direction,
+	DirectoryListing, DirectoryListingFile, DirectoryListingInput, FileStatus,
+	LoginOrRegisterArgs, PageInfo, PageQuery, PageableDirectoryListing,
+	PageableLibraries, PageableMedia, PageableSeries, PaginationQuery, QueryOrder,
+	ScanQueryParam, StumpVersion, UpdateLibraryArgs, UpdateUserArgs,
+	UserPreferencesUpdate,
 };
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
@@ -16,7 +17,7 @@ use utoipa_swagger_ui::SwaggerUi;
 use crate::errors::ApiError;
 use crate::utils::{
 	FilterableLibraryQuery, FilterableMediaQuery, FilterableSeriesQuery, LibraryFilter,
-	MediaFilter, SeriesFilter,
+	MediaFilter, SeriesFilter, SeriesRelation,
 };
 
 use super::api;
@@ -57,6 +58,24 @@ use super::api;
         api::v1::media::get_media_page,
         api::v1::media::get_media_thumbnail,
         api::v1::media::update_media_progress,
+        api::v1::reading_list::get_reading_list,
+        api::v1::reading_list::create_reading_list,
+        api::v1::reading_list::get_reading_list_by_id,
+        api::v1::reading_list::update_reading_list,
+        api::v1::reading_list::delete_reading_list_by_id,
+        api::v1::series::get_series,
+        api::v1::series::get_series_by_id,
+        api::v1::series::get_recently_added_series,
+        api::v1::series::get_series_thumbnail,
+        api::v1::series::get_series_media,
+        api::v1::series::get_next_in_series,
+        api::v1::user::get_users,
+        api::v1::user::create_user,
+        api::v1::user::delete_user_by_id,
+        api::v1::user::get_user_by_id,
+        api::v1::user::update_user,
+        api::v1::user::get_user_preferences,
+        api::v1::user::update_user_preferences,
     ),
     components(
         schemas(
@@ -68,7 +87,7 @@ use super::api;
             PageQuery, FilterableLibraryQuery, PaginationQuery, QueryOrder, LibraryFilter,
             Direction, CreateLibraryArgs, UpdateLibraryArgs, ApiError, MediaFilter, SeriesFilter,
             FilterableMediaQuery, FilterableSeriesQuery, JobReport, LibrariesStats, ScanQueryParam,
-            JobStatus
+            JobStatus, SeriesRelation, CreateReadingList, UserPreferencesUpdate, UpdateUserArgs
         )
     ),
     tags(

--- a/apps/server/src/utils/auth.rs
+++ b/apps/server/src/utils/auth.rs
@@ -45,6 +45,18 @@ pub fn get_writable_session_user(session: &WritableSession) -> ApiResult<User> {
 	}
 }
 
+// pub fn get_writable_session_admin_user(session: &WritableSession) -> ApiResult<User> {
+// 	let user = get_writable_session_user(session)?;
+
+// 	if user.is_admin() {
+// 		Ok(user)
+// 	} else {
+// 		Err(ApiError::Forbidden(
+// 			"You do not have permission to access this resource.".to_string(),
+// 		))
+// 	}
+// }
+
 pub fn get_session_admin_user(session: &ReadableSession) -> ApiResult<User> {
 	let user = get_session_user(session)?;
 

--- a/apps/server/src/utils/filter.rs
+++ b/apps/server/src/utils/filter.rs
@@ -69,7 +69,7 @@ pub struct LibraryFilter {
 	pub name: Vec<String>,
 }
 
-#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+#[derive(Default, Debug, Clone, Deserialize, Serialize, ToSchema)]
 pub struct SeriesRelation {
 	pub load_media: Option<bool>,
 }

--- a/apps/server/src/utils/filter.rs
+++ b/apps/server/src/utils/filter.rs
@@ -4,8 +4,10 @@ use serde::{de, Deserialize, Deserializer, Serialize};
 use serde_with::with_prefix;
 use std::fmt;
 use stump_core::prelude::QueryOrder;
+use utoipa::ToSchema;
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, ToSchema)]
+#[aliases(FilterableLibraryQuery = FilterableQuery<LibraryFilter>, FilterableSeriesQuery = FilterableQuery<SeriesFilter>, FilterableMediaQuery = FilterableQuery<MediaFilter>)]
 pub struct FilterableQuery<T>
 where
 	T: Sized + Default,
@@ -59,7 +61,7 @@ where
 }
 
 // TODO: tags
-#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+#[derive(Default, Debug, Clone, Deserialize, Serialize, ToSchema)]
 pub struct LibraryFilter {
 	#[serde(default, deserialize_with = "string_or_seq_string")]
 	pub id: Vec<String>,
@@ -76,7 +78,7 @@ pub struct SeriesRelation {
 // I would prefer /series?library[field]=value, but could not get that to work.
 with_prefix!(library_prefix "library_");
 
-#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+#[derive(Default, Debug, Clone, Deserialize, Serialize, ToSchema)]
 pub struct SeriesFilter {
 	#[serde(default, deserialize_with = "string_or_seq_string")]
 	pub id: Vec<String>,
@@ -90,7 +92,7 @@ pub struct SeriesFilter {
 // TODO: I don't like this convention and I'd rather figure out a way around it.
 // I would prefer /media?series[field]=value, but could not get that to work.
 with_prefix!(series_prefix "series_");
-#[derive(Default, Debug, Deserialize, Serialize)]
+#[derive(Default, Debug, Deserialize, Serialize, ToSchema)]
 pub struct MediaFilter {
 	#[serde(default)]
 	pub id: Vec<String>,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,7 @@ xml-rs = "0.8.4" # used for creating XML docs
 serde-xml-rs = "0.5.1" # used for serializing/deserializing xml
 itertools = "0.10.5"
 optional_struct = "0.2.0"
+utoipa = { version = "3.0.3" }
 
 ### FILESYSTEM UTILS ###
 walkdir = "2.3.2"

--- a/core/prisma/schema.prisma
+++ b/core/prisma/schema.prisma
@@ -81,7 +81,7 @@ model LibraryOptions {
   id                      String  @id @default(uuid())
   // Flag indicating whether or not to attempt to convert rar files to zip on scans.
   convert_rar_to_zip      Boolean @default(false)
-  // Flag indicating whether or not to *hard* delete rar files that were sucessfully converted to zip.
+  // Flag indicating whether or not to *hard* delete rar files that were successfully converted to zip.
   // Hard delete **will not be recoverable**. When false, converted files will be moved to the systems native
   // trash location, or a custom location when running in Docker (which will clear on an interval).
   hard_delete_conversions Boolean @default(false)

--- a/core/src/db/models/library.rs
+++ b/core/src/db/models/library.rs
@@ -2,12 +2,13 @@ use std::{fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use utoipa::ToSchema;
 
 use crate::prisma;
 
 use super::{series::Series, tag::Tag};
 
-#[derive(Debug, Clone, Deserialize, Serialize, Type)]
+#[derive(Debug, Clone, Deserialize, Serialize, Type, ToSchema)]
 pub struct Library {
 	pub id: String,
 	/// The name of the library. ex: "Marvel Comics"
@@ -28,7 +29,7 @@ pub struct Library {
 	pub library_options: LibraryOptions,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Type)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Type, ToSchema)]
 pub enum LibraryPattern {
 	#[serde(rename = "SERIES_BASED")]
 	SeriesBased,
@@ -72,7 +73,7 @@ impl fmt::Display for LibraryPattern {
 	}
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Type, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, Type, ToSchema, Default)]
 pub struct LibraryOptions {
 	// Note: this isn't really an Option, but I felt it was a little verbose
 	// to create an entirely new struct Create/UpdateLibraryOptions for just one
@@ -108,7 +109,7 @@ impl LibraryOptions {
 // 	}
 // }
 
-#[derive(Deserialize, Debug, PartialEq, Eq, Copy, Clone, Type)]
+#[derive(Deserialize, Debug, PartialEq, Eq, Copy, Clone, Type, ToSchema)]
 pub enum LibraryScanMode {
 	#[serde(rename = "SYNC")]
 	Sync,
@@ -146,7 +147,7 @@ impl Default for LibraryScanMode {
 	}
 }
 
-#[derive(Deserialize, Serialize, Type)]
+#[derive(Deserialize, Serialize, Type, ToSchema)]
 pub struct LibrariesStats {
 	series_count: u64,
 	book_count: u64,

--- a/core/src/db/models/log.rs
+++ b/core/src/db/models/log.rs
@@ -2,19 +2,20 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use utoipa::ToSchema;
 
 use crate::event::CoreEvent;
 
 /// Information about the Stump log file, located at STUMP_CONFIG_DIR/Stump.log, or
 /// ~/.stump/Stump.log by default. Information such as the file size, last modified date, etc.
-#[derive(Serialize, Deserialize, Type)]
+#[derive(Serialize, Deserialize, Type, ToSchema)]
 pub struct LogMetadata {
 	pub path: PathBuf,
 	pub size: u64,
 	pub modified: String,
 }
 
-#[derive(Clone, Serialize, Deserialize, Type)]
+#[derive(Clone, Serialize, Deserialize, Type, ToSchema)]
 pub enum LogLevel {
 	#[serde(rename = "ERROR")]
 	Error,
@@ -43,7 +44,7 @@ impl std::fmt::Display for LogLevel {
 	}
 }
 
-#[derive(Clone, Serialize, Deserialize, Default, Type)]
+#[derive(Clone, Serialize, Deserialize, Default, Type, ToSchema)]
 pub struct Log {
 	pub id: String,
 	pub level: LogLevel,

--- a/core/src/db/models/media.rs
+++ b/core/src/db/models/media.rs
@@ -3,6 +3,7 @@ use std::{path::Path, str::FromStr};
 use optional_struct::OptionalStruct;
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use utoipa::ToSchema;
 
 use crate::{
 	prelude::{enums::FileStatus, CoreError, CoreResult},
@@ -11,7 +12,9 @@ use crate::{
 
 use super::{read_progress::ReadProgress, series::Series, tag::Tag, LibraryOptions};
 
-#[derive(Debug, Clone, Deserialize, Serialize, Type, Default, OptionalStruct)]
+#[derive(
+	Debug, Clone, Deserialize, Serialize, Type, Default, OptionalStruct, ToSchema,
+)]
 #[optional_name = "PartialMedia"]
 #[optional_derive(Deserialize, Serialize)]
 pub struct Media {

--- a/core/src/db/models/read_progress.rs
+++ b/core/src/db/models/read_progress.rs
@@ -1,12 +1,13 @@
 use serde::{Deserialize, Serialize};
 use specta::Type;
 use tracing::trace;
+use utoipa::ToSchema;
 
 use crate::prisma;
 
 use super::{media::Media, user::User};
 
-#[derive(Debug, Clone, Deserialize, Serialize, Type, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, Type, ToSchema, Default)]
 pub struct ReadProgress {
 	pub id: String,
 	/// The current page

--- a/core/src/db/models/reading_list.rs
+++ b/core/src/db/models/reading_list.rs
@@ -1,9 +1,10 @@
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use utoipa::ToSchema;
 
 use crate::{db::models::Media, prisma::reading_list};
 
-#[derive(Debug, Clone, Serialize, Deserialize, Type, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Type, ToSchema, Default)]
 pub struct ReadingList {
 	pub id: String,
 	pub name: String,

--- a/core/src/db/models/series.rs
+++ b/core/src/db/models/series.rs
@@ -2,12 +2,13 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use utoipa::ToSchema;
 
 use crate::{prelude::enums::FileStatus, prisma};
 
 use super::{library::Library, media::Media, tag::Tag};
 
-#[derive(Debug, Clone, Deserialize, Serialize, Type)]
+#[derive(Debug, Clone, Deserialize, Serialize, Type, ToSchema)]
 pub struct Series {
 	pub id: String,
 	/// The name of the series. ex: "The Amazing Spider-Man (2018)"

--- a/core/src/db/models/tag.rs
+++ b/core/src/db/models/tag.rs
@@ -1,9 +1,10 @@
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use utoipa::ToSchema;
 
 use crate::prisma;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[derive(Debug, Clone, Serialize, Deserialize, Type, ToSchema)]
 pub struct Tag {
 	pub id: String,
 	/// The name of the tag. ex: "comic"

--- a/core/src/db/models/user.rs
+++ b/core/src/db/models/user.rs
@@ -1,9 +1,10 @@
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use utoipa::ToSchema;
 
 use crate::prisma;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[derive(Debug, Clone, Serialize, Deserialize, Type, ToSchema)]
 pub struct User {
 	pub id: String,
 	pub username: String,
@@ -39,7 +40,7 @@ impl From<prisma::user::Data> for User {
 	}
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[derive(Debug, Clone, Serialize, Deserialize, Type, ToSchema)]
 
 pub struct UserPreferences {
 	pub id: String,

--- a/core/src/job/mod.rs
+++ b/core/src/job/mod.rs
@@ -3,6 +3,7 @@ pub mod pool;
 pub mod runner;
 
 pub use jobs::*;
+use utoipa::ToSchema;
 
 use std::{fmt::Debug, num::TryFromIntError};
 
@@ -101,7 +102,7 @@ pub enum JobEvent {
 	Failed,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, Type)]
+#[derive(Clone, Serialize, Deserialize, Debug, Type, ToSchema)]
 pub enum JobStatus {
 	#[serde(rename = "RUNNING")]
 	Running,
@@ -211,7 +212,7 @@ impl JobUpdate {
 	}
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, Type)]
+#[derive(Clone, Serialize, Deserialize, Debug, Type, ToSchema)]
 pub struct JobReport {
 	/// This will actually refer to the job runner id
 	pub id: Option<String>,

--- a/core/src/prelude/enums.rs
+++ b/core/src/prelude/enums.rs
@@ -2,8 +2,9 @@ use std::{fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use utoipa::ToSchema;
 
-#[derive(Serialize, Deserialize, Type)]
+#[derive(Serialize, Deserialize, Type, ToSchema)]
 pub enum UserRole {
 	#[serde(rename = "SERVER_OWNER")]
 	ServerOwner,
@@ -11,7 +12,7 @@ pub enum UserRole {
 	Member,
 }
 
-#[derive(Serialize, Deserialize, Type)]
+#[derive(Serialize, Deserialize, Type, ToSchema)]
 pub enum LayoutMode {
 	#[serde(rename = "GRID")]
 	Grid,
@@ -19,7 +20,7 @@ pub enum LayoutMode {
 	List,
 }
 
-#[derive(Debug, Deserialize, Serialize, Type, Clone, Copy)]
+#[derive(Debug, Deserialize, Serialize, Type, ToSchema, Clone, Copy)]
 pub enum FileStatus {
 	#[serde(rename = "UNKNOWN")]
 	Unknown,

--- a/core/src/prelude/fs/list_directory.rs
+++ b/core/src/prelude/fs/list_directory.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Deserialize, Serialize, Type)]
+#[derive(Debug, Clone, Deserialize, Serialize, Type, ToSchema)]
 pub struct DirectoryListingInput {
 	pub path: Option<String>,
 }
@@ -14,13 +15,13 @@ impl Default for DirectoryListingInput {
 	}
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Type)]
+#[derive(Debug, Clone, Deserialize, Serialize, Type, ToSchema)]
 pub struct DirectoryListing {
 	pub parent: Option<String>,
 	pub files: Vec<DirectoryListingFile>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Type)]
+#[derive(Debug, Clone, Deserialize, Serialize, Type, ToSchema)]
 pub struct DirectoryListingFile {
 	pub is_directory: bool,
 	pub name: String,

--- a/core/src/prelude/server/inputs.rs
+++ b/core/src/prelude/server/inputs.rs
@@ -81,3 +81,8 @@ pub struct CreateReadingList {
 	pub id: String,
 	pub media_ids: Vec<String>,
 }
+
+#[derive(Deserialize, Type, ToSchema)]
+pub struct CreateTags {
+	pub tags: Vec<String>,
+}

--- a/core/src/prelude/server/inputs.rs
+++ b/core/src/prelude/server/inputs.rs
@@ -71,6 +71,11 @@ pub struct UpdateLibraryArgs {
 	pub scan_mode: Option<LibraryScanMode>,
 }
 
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct ScanQueryParam {
+	pub scan_mode: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Type, ToSchema)]
 pub struct CreateReadingList {
 	pub id: String,

--- a/core/src/prelude/server/inputs.rs
+++ b/core/src/prelude/server/inputs.rs
@@ -1,9 +1,10 @@
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use utoipa::ToSchema;
 
 use crate::db::models::{LibraryOptions, LibraryScanMode, Tag};
 
-#[derive(Debug, Clone, Deserialize, Type)]
+#[derive(Debug, Clone, Deserialize, Type, ToSchema)]
 pub struct UserPreferencesUpdate {
 	pub id: String,
 	pub locale: String,
@@ -18,24 +19,24 @@ pub struct DecodedCredentials {
 	pub password: String,
 }
 
-#[derive(Deserialize, Type)]
+#[derive(Deserialize, Type, ToSchema)]
 pub struct LoginOrRegisterArgs {
 	pub username: String,
 	pub password: String,
 }
 
-#[derive(Deserialize, Type)]
+#[derive(Deserialize, Type, ToSchema)]
 pub struct UpdateUserArgs {
 	pub username: String,
 	pub password: Option<String>,
 }
 
-#[derive(Serialize, Type)]
+#[derive(Serialize, Type, ToSchema)]
 pub struct ClaimResponse {
 	pub is_claimed: bool,
 }
 
-#[derive(Deserialize, Debug, Type)]
+#[derive(Deserialize, Debug, Type, ToSchema)]
 pub struct CreateLibraryArgs {
 	/// The name of the library to create.
 	pub name: String,
@@ -51,7 +52,7 @@ pub struct CreateLibraryArgs {
 	pub library_options: Option<LibraryOptions>,
 }
 
-#[derive(Deserialize, Debug, Type)]
+#[derive(Deserialize, Debug, Type, ToSchema)]
 pub struct UpdateLibraryArgs {
 	pub id: String,
 	/// The updated name of the library.
@@ -70,7 +71,7 @@ pub struct UpdateLibraryArgs {
 	pub scan_mode: Option<LibraryScanMode>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[derive(Debug, Clone, Serialize, Deserialize, Type, ToSchema)]
 pub struct CreateReadingList {
 	pub id: String,
 	pub media_ids: Vec<String>,

--- a/core/src/prelude/server/mod.rs
+++ b/core/src/prelude/server/mod.rs
@@ -10,8 +10,9 @@ pub use http::*;
 pub use inputs::*;
 pub use pageable::*;
 pub use query::*;
+use utoipa::ToSchema;
 
-#[derive(Serialize, Deserialize, Type)]
+#[derive(Serialize, Deserialize, Type, ToSchema)]
 pub struct StumpVersion {
 	pub semver: String,
 	pub rev: Option<String>,

--- a/core/src/prelude/server/query.rs
+++ b/core/src/prelude/server/query.rs
@@ -1,12 +1,13 @@
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use utoipa::ToSchema;
 
 use crate::{
 	prelude::errors::CoreError,
 	prisma::{library, media, series},
 };
 
-#[derive(Debug, Serialize, Deserialize, Clone, Type)]
+#[derive(Debug, Serialize, Deserialize, Clone, Type, ToSchema)]
 pub enum Direction {
 	#[serde(rename = "asc")]
 	Asc,
@@ -30,7 +31,7 @@ impl From<Direction> for prisma_client_rust::Direction {
 }
 
 /// Model used in media API to alter sorting/ordering of queried media
-#[derive(Debug, Deserialize, Serialize, Type)]
+#[derive(Debug, Deserialize, Serialize, Type, ToSchema)]
 #[serde(default)]
 pub struct QueryOrder {
 	/// The field to order by. Defaults to 'name'

--- a/packages/interface/src/components/ServerUrlForm.tsx
+++ b/packages/interface/src/components/ServerUrlForm.tsx
@@ -131,7 +131,7 @@ export default function ServerUrlForm() {
 
 				{sucessfulConnection && (
 					<FormHelperText color="green.300">
-						Sucessfully connected to {form.getValues('baseUrl')}!
+						Successfully connected to {form.getValues('baseUrl')}!
 					</FormHelperText>
 				)}
 			</FormControl>


### PR DESCRIPTION
Resolves https://github.com/aaronleopold/stump/issues/63

This PR adds [utoipa](https://github.com/juhaku/utoipa) and annotations for all of the `api/v1` routers/endpoints. This will generate OpenAPI docs for all of the annotated sections, as well as provide access to Swagger UI at `http(s)://your-server(:10801)/swagger-ui`