### PR TITLE
fix(maybe lol): limit concurrency

### DIFF
--- a/core/src/fs/scanner/batch_scanner.rs
+++ b/core/src/fs/scanner/batch_scanner.rs
@@ -126,7 +126,7 @@ pub async fn scan(ctx: RunnerCtx, path: String, runner_id: String) -> CoreResult
 	persist_job_start(&core_ctx, runner_id.clone(), tasks).await?;
 
 	let counter = Arc::new(AtomicU64::new(0));
-	let handle_iter = library_series.into_iter().map(|s| async {
+	let future_iter = library_series.into_iter().map(|s| async {
 		let progress_ctx = ctx.clone();
 		let scanner_ctx = core_ctx.clone();
 
@@ -148,7 +148,7 @@ pub async fn scan(ctx: RunnerCtx, path: String, runner_id: String) -> CoreResult
 		.await
 	});
 
-	let operations = futures::stream::iter(handle_iter)
+	let operations = futures::stream::iter(future_iter)
 		// Execute up to 10 in parallel
 		.buffer_unordered(10)
 		.collect::<Vec<_>>()

--- a/core/src/job/jobs.rs
+++ b/core/src/job/jobs.rs
@@ -29,7 +29,6 @@ impl Job for LibraryScanJob {
 			self.scan_mode,
 			self.path.clone(),
 		);
-		// persist_job_end(&ctx, runner_id, completed_tasks, duration.as_millis()).await?;
 
 		Ok(result)
 	}


### PR DESCRIPTION
I am introducing a concurrency limit for the batch scan, something that definitely should have previously been in place. Rather than spawning threads for each series, no additional threads are spawned (except in the file count calculation, but that will be tacked later down the road). The `scan_series` futures are streamed and ran in parallel up to 10 at a time. I'm hopeful this alone will help with some of the memory issues for massive libraries, outlined in https://github.com/aaronleopold/stump/issues/102. 